### PR TITLE
Remove et al in bibliography

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -28,7 +28,7 @@
 
 @article{chen2021evaluating,
   title={Evaluating large language models trained on code},
-  author={Chen, Mark and others},
+  author={Chen, Mark},
   eprint={2107.03374},
   archivePrefix={arXiv},
   primaryClass={cs.LG},
@@ -162,7 +162,7 @@
 }
 
 @misc{bozkurt2024genai,
-  title={GenAI et al. Cocreation, authorship, ownership, academic ethics and integrity in a time of generative AI},
+  title={GenAI Cocreation, authorship, ownership, academic ethics and integrity in a time of generative AI},
   author={Bozkurt, Aras},
   journal={Open Praxis},
   volume={16},
@@ -411,7 +411,7 @@
 }
 
 @inproceedings{karpukhin2020dense,
-  author={Karpukhin, V. and Oğuz, B. and Min, S. and Lewis, P. and Wu, L. and Edunov, S. and Yih, W.},
+  author={Karpukhin, V. and Oğuz, B. Min, S. and Lewis, P.,  Wu, L. and Edunov, S. and Yih, W.},
   title={Dense Passage Retrieval for Open-Domain Question Answering},
   booktitle={Proceedings of EMNLP 2020},
   year={2020},
@@ -481,14 +481,14 @@
 }
 
 @inproceedings{karpukhin2020dpr,
-  author={Karpukhin, V. and Oguz, B. and Min, S. and others},
+  author={Karpukhin, V. and Oguz, B. and Min, S.},
   title={Dense Passage Retrieval for Open-Domain Question Answering},
   booktitle={Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP)},
   year={2020}
 }
 
 @article{shuster2023rag,
-  author={Shuster, K. and Ju, D. and Roller, S. and others},
+  author={Shuster, K. and Ju, D. and Roller, S.},
   title={Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks: Challenges and Advances},
   journal={Transactions of the Association for Computational Linguistics},
   volume={11},
@@ -678,7 +678,7 @@
 }
 
 @article{naveed2024,
-  author    = {Naveed, Muhammad and others},
+  author    = {Naveed, Muhammad},
   title     = {Large Language Models and Their Impact on NLP Tasks},
   year      = {2024},
   journal   = {Journal of Natural Language Processing Research}
@@ -728,7 +728,8 @@
 
 @article{comanici2025gem,
   title={Gemini 2.5: Pushing the frontier with advanced reasoning, multimodality, long context, and next generation agentic capabilities},
-  author={Comanici, Gheorghe and Bieber, Eric and Schaekermann, Mike and Pasupat, Ice and Sachdeva, Noveen and Dhillon, Inderjit and Blistein, Marcel and Ram, Ori and Zhang, Dan and Rosen, Evan and others},
+  author={Comanici, Gheorghe and Bieber, Eric and Schaekermann, Mike and Pasupat, Ice and Sachdeva, Noveen and Dhillon, Inderjit and Blistein, Marcel and Ram, Ori and Zhang, Dan and Rosen, Evan
+},
   journal={arXiv preprint arXiv:2507.06261},
   year={2025},
   url={https://arxiv.org/abs/2507.06261}
@@ -737,7 +738,7 @@
 
 @article{folstad2021future,
   title={Future directions for chatbot research: an interdisciplinary research agenda},
-  author={F{\o}lstad, Asbj{\o}rn and Araujo, Theo and Law, Effie Lai-Chong and Brandtzaeg, Petter Bae and Papadopoulos, Symeon and Reis, Lea and Baez, Marcos and Laban, Guy and McAllister, Patrick and Ischen, Carolin and others},
+  author={F{\o}lstad, Asbj{\o}rn and Araujo, Theo and Law, Effie Lai-Chong and Brandtzaeg, Petter Bae and Papadopoulos, Symeon and Reis, Lea and Baez, Marcos and Laban, Guy and McAllister, Patrick and Ischen, Carolin},
   journal={Computing},
   volume={103},
   number={12},


### PR DESCRIPTION
Removed 'and others' from multiple author fields for clarity.